### PR TITLE
Adds snippet for knitr::include_graphics

### DIFF
--- a/markdown.snippets
+++ b/markdown.snippets
@@ -205,3 +205,12 @@ snippet lrnq
 	  random_answer_order = TRUE
 	)
 	```
+
+# ------------------------------------------------------------
+# knitr
+# ------------------------------------------------------------
+
+snippet fig
+	```{r ${1:chunk-name}, echo=FALSE}
+	knitr::include_graphics(${2:location})
+	```


### PR DESCRIPTION
Thank you for creating these markdown snippets; they are magical! 

Here is a PR that adds one for `knitr::include_graphics` with snippet `fig`